### PR TITLE
Code enhancement for checking the cache data before hitting the API

### DIFF
--- a/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/CourseEnrolmentActor.scala
+++ b/course-mw/enrolment-actor/src/main/scala/org/sunbird/enrolments/CourseEnrolmentActor.scala
@@ -435,12 +435,7 @@ class CourseEnrolmentActor @Inject()(@Named("course-batch-notification-actor") c
         val programId: String = request.get(JsonKey.PROGRAM_ID).asInstanceOf[String]
         val isAdminAPI: Boolean = request.get(JsonKey.IS_ADMIN_API).asInstanceOf[Boolean]
         val fieldList = List(JsonKey.PRIMARYCATEGORY, JsonKey.IDENTIFIER, JsonKey.BATCHES)
-        val responseString = cacheUtil.get(programId)
-        val contentData: util.Map[String, AnyRef] = if (responseString != null) {
-            JsonUtil.deserialize(responseString, new util.HashMap[String, AnyRef]().getClass)
-        } else {
-            ContentUtil.getContentReadV3(programId, fieldList,request.getContext.getOrDefault(JsonKey.HEADER, new util.HashMap[String, String]).asInstanceOf[util.Map[String, String]])
-        }
+        val contentData = getContentReadAPIData(programId,fieldList, request)
         if(isAdminAPI && (contentData.size() == 0 || !util.Arrays.asList(getConfigValue(JsonKey.ADMIN_PROGRAM_ENROLL_ALLOWED_PRIMARY_CATEGORY).split(","): _*).contains(contentData.get(JsonKey.PRIMARYCATEGORY).asInstanceOf[String])))
             ProjectCommonException.throwClientErrorException(ResponseCode.accessDeniedToEnrolOrUnenrolCourse, programId);
         if (contentData.size() == 0 || !util.Arrays.asList(getConfigValue(JsonKey.PROGRAM_ENROLL_ALLOWED_PRIMARY_CATEGORY).split(","): _*).contains(contentData.get(JsonKey.PRIMARYCATEGORY).asInstanceOf[String]))
@@ -460,6 +455,16 @@ class CourseEnrolmentActor @Inject()(@Named("course-batch-notification-actor") c
         sender().tell(successResponse(), self)
         generateTelemetryAudit(userId, programId, batchId, data, "enrol", JsonKey.CREATE, request.getContext)
         notifyUser(userId, batchData, JsonKey.ADD)
+    }
+
+    def getContentReadAPIData(programId: String, fieldList: List[String], request: Request): util.Map[String, AnyRef] = {
+        val responseString: String = cacheUtil.get(programId)
+        val contentData: util.Map[String, AnyRef] = if (responseString != null) {
+            JsonUtil.deserialize(responseString, new util.HashMap[String, AnyRef]().getClass)
+        } else {
+            ContentUtil.getContentReadV3(programId, fieldList, request.getContext.getOrDefault(JsonKey.HEADER, new util.HashMap[String, String]).asInstanceOf[util.Map[String, String]])
+        }
+        contentData
     }
 
     def getCoursesForProgramAndEnrol(request: Request, programId: String, userId: String, batchId: String) = {


### PR DESCRIPTION
1. Redis Cache Implementation for the Content Read API call- used the  existing get()  implementaton available in the RedisCacheUtil and passed the key which is the programId and if the data is not null then converted the String to the type Map<String,AnyRef> using the JsonUtil.deserialize.

